### PR TITLE
http request fix for CF 9.0.1

### DIFF
--- a/Stripe.cfc
+++ b/Stripe.cfc
@@ -725,9 +725,10 @@ component name="Stripe" output=false accessors=true description="ColdFusion Wrap
 	
 /* HELPER FUNCTIONS */	
 
-	private HTTP function createHTTPService(string urlmethod='POST', int httptimeout=1000) {
+	private HTTP function createHTTPService(string urlmethod='POST', numeric httptimeout=1000) {
 		local.HTTPService = new HTTP();
 		local.HTTPService.setUsername(getStripeApiKey());
+		local.HTTPService.setPassword('');
 		local.HTTPService.setMethod(arguments.urlmethod);
 		local.HTTPService.setCharset('utf-8');
 		local.HTTPService.setTimeout(arguments.httptimeout);


### PR DESCRIPTION
On ColdFusion 9.0.1, I found that not setting a password was causing a 401 Not Authorized response from Stripe.  So I set a blank password in the createHTTP function.

I also changed the argument type of httptimeout from "int" to "numeric" as CF 9.0.1 wasn't understanding "int" as a type.
