### PR TITLE
update to utcIntToTime

### DIFF
--- a/Stripe.cfc
+++ b/Stripe.cfc
@@ -753,9 +753,8 @@ component name="Stripe" output=false accessors=true description="ColdFusion Wrap
 		return local.intUTCDate;
 	}
 	
-	public datetime function utcIntToTime(required numeric intUtcTime) {
-		local.baseDate = CreateDateTime(1970,1,1,0,0,0);
-		return DateAdd('s',arguments.intUtcTime,DateConvert('utc2Local',local.baseDate));;
+	public date function utcIntToTime(required numeric intUtcTime) {
+		return DateAdd('s',arguments.intUtcTime,CreateDateTime(1970,1,1,0,0,0));
 	}
 	
 }


### PR DESCRIPTION
Hey man, thanks for this nice component. on CF10, I couldn't get utcIntToTime to work because cf did not recognize the datetime return time (expected date instead).

Also, made an adjustment to how the time was calculated based on this thread: http://stackoverflow.com/questions/13209751/how-to-format-stripe-timestamp-in-coldfusion

That worked well for me...
